### PR TITLE
undefined: ServerPath error workaround

### DIFF
--- a/server_windows.go
+++ b/server_windows.go
@@ -1,0 +1,6 @@
+// +build windows
+
+package sc
+
+// ServerPath is the path the scsynth executable on linux systems.
+const ServerPath = ""

--- a/server_windows.go
+++ b/server_windows.go
@@ -1,0 +1,6 @@
+// +build windows
+
+package sc
+
+// ServerPath is the path the scsynth executable on windows systems.
+const ServerPath = ""


### PR DESCRIPTION
This is to prevent the `sc\server.go:33:37: undefined: ServerPath` error on **Windows build**.